### PR TITLE
Update to 1.21.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric properties https://fabricmc.net/develop
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
-loader_version=0.17.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.17.3
 
 # Dependencies
-fabric_version=0.131.0+1.21.8
-fabric_kotlin_version=1.13.4+kotlin.2.2.0
+fabric_version=0.135.0+1.21.10
+fabric_kotlin_version=1.13.7+kotlin.2.2.21
 loom_version=1.11-SNAPSHOT
 jackson_version=2.14.2
 jackson_kotlin_version=2.14.3

--- a/src/main/kotlin/com/ac101m/am/AutonomousMinecarts.kt
+++ b/src/main/kotlin/com/ac101m/am/AutonomousMinecarts.kt
@@ -38,8 +38,7 @@ class AutonomousMinecarts(private val environment: Environment) {
 
         val chunkTicketType = ChunkTicketType(
             config.ticketDuration.toLong(),
-            false,
-            ChunkTicketType.Use.LOADING_AND_SIMULATION
+            15
         )
 
         Utils.AM_CHUNK_TICKET_TYPE = Registry.register(

--- a/src/main/kotlin/com/ac101m/am/MinecartTracker.kt
+++ b/src/main/kotlin/com/ac101m/am/MinecartTracker.kt
@@ -17,7 +17,7 @@ class MinecartTracker(
      * Vector exponential moving average of cart position.
      * Used to filter out carts which are moving but not leaving a confined area.
      */
-    private var smoothedPos = minecart.pos
+    private var smoothedPos = minecart.entityPos
 
     /**
      * "Active" minecarts are minecarts which are moving in a way that satisfies the mods loading criteria.
@@ -33,11 +33,11 @@ class MinecartTracker(
     fun update(minecart: AbstractMinecartEntity) {
         this.minecart = minecart
 
-        smoothedPos = minecart.pos.multiply(config.positionAverageFactor).add(smoothedPos!!.multiply(1.0 - config.positionAverageFactor))
+        smoothedPos = minecart.entityPos.multiply(config.positionAverageFactor).add(smoothedPos!!.multiply(1.0 - config.positionAverageFactor))
 
         minecartIsActive = if (minecart.velocity.length() < config.idleThreshold) {
             false
-        } else if (smoothedPos.subtract(minecart.pos).length() < config.positionAverageDistance) {
+        } else if (smoothedPos.subtract(minecart.entityPos).length() < config.positionAverageDistance) {
             false
         } else {
             true

--- a/src/main/kotlin/com/ac101m/am/WorldTracker.kt
+++ b/src/main/kotlin/com/ac101m/am/WorldTracker.kt
@@ -110,7 +110,7 @@ class WorldTracker(
             if (tracker.minecartIsActive) {
                 ticketHandlers.computeIfAbsent(id) {
                     TicketHandler(
-                        world = tracker.minecart.world as ServerWorld,
+                        world = tracker.minecart.entityWorld as ServerWorld,
                         chunkPos =  tracker.minecart.chunkPos,
                         config = config,
                         idleCounter = 0


### PR DESCRIPTION
Looks like ChunkTicketTypes were refactored. I just used the same flags as `"forced"` and `"portal"`

```java
   public static final long NO_EXPIRATION = 0L;
   public static final int SERIALIZE = 1;
   public static final int FOR_LOADING = 2;
   public static final int FOR_SIMULATION = 4;
   public static final int RESETS_IDLE_TIMEOUT = 8;
   public static final int CAN_EXPIRE_BEFORE_LOAD = 16;
   public static final ChunkTicketType PLAYER_SPAWN = register("player_spawn", 20L, 2);
   public static final ChunkTicketType SPAWN_SEARCH = register("spawn_search", 1L, 2);
   public static final ChunkTicketType DRAGON = register("dragon", 0L, 6);
   public static final ChunkTicketType PLAYER_LOADING = register("player_loading", 0L, 2);
   public static final ChunkTicketType PLAYER_SIMULATION = register("player_simulation", 0L, 12);
   public static final ChunkTicketType FORCED = register("forced", 0L, 15);
   public static final ChunkTicketType PORTAL = register("portal", 300L, 15);
   public static final ChunkTicketType ENDER_PEARL = register("ender_pearl", 40L, 14);
   public static final ChunkTicketType UNKNOWN = register("unknown", 1L, 18);
```