### PR TITLE
Backport to version 1.21.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ jackson_kotlin_version=2.14.3
 junit_version=5.9.2
 
 # Mod properties
-mod_version = 1.1.8
+mod_version = 1.1.9+1.21.10
 maven_group = com.ac101m
 archives_base_name = autonomous-minecarts

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.configuration-cache=false
 
 # Fabric properties https://fabricmc.net/develop
-minecraft_version=1.21.11
+minecraft_version=1.21.10
 loader_version=0.18.4
 loom_version=1.14-SNAPSHOT
-yarn_mappings=1.21.11+build.1
+yarn_mappings=1.21.10+build.1
 
 # Dependencies`
-fabric_api_version=0.141.1+1.21.11
+fabric_api_version=0.138.4+1.21.10
 fabric_kotlin_version=1.13.8+kotlin.2.3.0
 jackson_version=2.14.2
 jackson_kotlin_version=2.14.3

--- a/src/main/kotlin/com/ac101m/am/AutonomousMinecarts.kt
+++ b/src/main/kotlin/com/ac101m/am/AutonomousMinecarts.kt
@@ -57,6 +57,8 @@ class AutonomousMinecarts(private val environment: Environment) {
     fun onServerStart() {
         log.info("Starting autonomous minecarts...")
 
+        trackedWorlds.clear()
+
         val statePath = Path.of(environment.worldDirectory.toString(), STATE_FILE_NAME)
 
         startupState = try {

--- a/src/main/kotlin/com/ac101m/am/AutonomousMinecarts.kt
+++ b/src/main/kotlin/com/ac101m/am/AutonomousMinecarts.kt
@@ -8,9 +8,8 @@ import com.ac101m.am.persistence.PersistentMinecartTicket
 import net.minecraft.core.Registry
 import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.server.level.ServerLevel
-import net.minecraft.resources.Identifier
+import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.TicketType
-import net.minecraft.server.level.TicketType.FLAG_KEEP_DIMENSION_ACTIVE
 import net.minecraft.server.level.TicketType.FLAG_LOADING
 import net.minecraft.server.level.TicketType.FLAG_PERSIST
 import net.minecraft.server.level.TicketType.FLAG_SIMULATION
@@ -27,7 +26,7 @@ class AutonomousMinecarts(private val environment: Environment) {
     private var config: Config
     private var startupState: StartupState? = null
 
-    private val trackedWorlds = HashMap<Identifier, WorldTracker>()
+    private val trackedWorlds = HashMap<ResourceLocation, WorldTracker>()
 
     init {
         val configPath = Path.of(environment.configDirectory.toString(), CONFIG_FILE_NAME)
@@ -42,7 +41,7 @@ class AutonomousMinecarts(private val environment: Environment) {
 
         val chunkTicketType = TicketType(
             config.ticketDuration.toLong(),
-            FLAG_PERSIST or FLAG_LOADING or FLAG_SIMULATION or FLAG_KEEP_DIMENSION_ACTIVE
+            FLAG_PERSIST or FLAG_LOADING or FLAG_SIMULATION
         )
 
         Utils.AM_CHUNK_TICKET_TYPE = Registry.register(
@@ -105,7 +104,7 @@ class AutonomousMinecarts(private val environment: Environment) {
                 continue
             }
 
-            trackedWorlds.computeIfAbsent(world.dimension().identifier()) {
+            trackedWorlds.computeIfAbsent(world.dimension().location()) {
                 WorldTracker(world, config)
             }.loadPersistedTicket(ticket)
         }
@@ -117,7 +116,7 @@ class AutonomousMinecarts(private val environment: Environment) {
      * Update tracked worlds and world idle state.
      */
     fun beforeWorldTick(world: ServerLevel) {
-        trackedWorlds.computeIfAbsent(world.dimension().identifier()) {
+        trackedWorlds.computeIfAbsent(world.dimension().location()) {
             WorldTracker(world, config)
         }.updateWorldIdle(world)
     }
@@ -126,7 +125,7 @@ class AutonomousMinecarts(private val environment: Environment) {
      * Update minecart trackers, create trackers where necessary.
      */
     fun afterWorldTick(world: ServerLevel) {
-        trackedWorlds[world.dimension().identifier()]!!.updateMinecarts(world)
+        trackedWorlds[world.dimension().location()]!!.updateMinecarts(world)
     }
 
     companion object {

--- a/src/main/kotlin/com/ac101m/am/MinecartTracker.kt
+++ b/src/main/kotlin/com/ac101m/am/MinecartTracker.kt
@@ -2,7 +2,7 @@ package com.ac101m.am
 
 import com.ac101m.am.Utils.Companion.multiply
 import com.ac101m.am.persistence.Config
-import net.minecraft.world.entity.vehicle.minecart.AbstractMinecart
+import net.minecraft.world.entity.vehicle.AbstractMinecart
 
 /**
  * Tracks minecart behaviour and decides whether a cart is idle or not.

--- a/src/main/kotlin/com/ac101m/am/TicketHandler.kt
+++ b/src/main/kotlin/com/ac101m/am/TicketHandler.kt
@@ -70,7 +70,7 @@ class TicketHandler(
             x = chunkPos.x,
             z = chunkPos.z,
             idleTicks = idleCounter,
-            worldName = world.dimension().identifier().toString()
+            worldName = world.dimension().location().toString()
         )
     }
 }

--- a/src/main/kotlin/com/ac101m/am/Utils.kt
+++ b/src/main/kotlin/com/ac101m/am/Utils.kt
@@ -27,7 +27,7 @@ class Utils {
          */
         fun MinecraftServer.getWorldByName(name: String): ServerLevel? {
             return allLevels.find { world ->
-                world.dimension().identifier().toString() == name
+                world.dimension().location().toString() == name
             }
         }
 

--- a/src/main/kotlin/com/ac101m/am/WorldTracker.kt
+++ b/src/main/kotlin/com/ac101m/am/WorldTracker.kt
@@ -4,7 +4,7 @@ import com.ac101m.am.persistence.Config
 import com.ac101m.am.persistence.PersistentMinecartTicket
 import net.minecraft.world.entity.Entity
 import net.minecraft.server.level.ServerLevel
-import net.minecraft.world.entity.vehicle.minecart.AbstractMinecart
+import net.minecraft.world.entity.vehicle.AbstractMinecart
 import net.minecraft.world.level.ChunkPos
 import net.minecraft.world.level.entity.EntityTypeTest
 import org.slf4j.LoggerFactory

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
   },
   "depends": {
     "fabricloader": ">=0.18.4",
-    "minecraft": "~1.21.10",
+    "minecraft": "1.21.10",
     "java": ">=21",
     "fabric-api": "*",
     "fabric-language-kotlin": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
   },
   "depends": {
     "fabricloader": ">=0.18.4",
-    "minecraft": "~1.21.11",
+    "minecraft": "~1.21.10",
     "java": ">=21",
     "fabric-api": "*",
     "fabric-language-kotlin": "*"


### PR DESCRIPTION
Backport to 1.21.10

Tested it and works correctly, just without the "keep dimension active" behaviour since FLAG_KEEP_DIMENSION_ACTIVE, doesn't exist in 1.21.10,

Closes #10 